### PR TITLE
Replace deprecated api function with nvim_cmd()

### DIFF
--- a/lua/telescope/_extensions/scriptnames.lua
+++ b/lua/telescope/_extensions/scriptnames.lua
@@ -3,12 +3,8 @@ local finders = require("telescope.finders")
 local conf = require("telescope.config").values
 
 local function prepare_output_table()
-  local lines = {}
-  local scripts = vim.api.nvim_command_output("scriptnames")
-
-  for script in scripts:gmatch("[^\r\n]+") do
-      table.insert(lines, script)
-  end
+  local scripts = vim.api.nvim_cmd({ cmd = "scriptnames" }, { output = true })
+  local lines = vim.split(scripts, "\r?\n")
   return lines
 end
 


### PR DESCRIPTION
The api func `nvim_command_output()` is deprecated. Replaced with `nvim_cmd()`.

Also removed unnecessary `for` loop to use `vim.split()` directly on the command output.